### PR TITLE
fix syntax to swift3. (NSAttributedStringKey, etc.)

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -298,13 +298,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = alexsmetdev.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -315,13 +316,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = alexsmetdev.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/NumbersScrollAnimatedView/NumberScrollAnimatedView.swift
+++ b/NumbersScrollAnimatedView/NumberScrollAnimatedView.swift
@@ -89,7 +89,7 @@ public class NumberScrollAnimatedView: UIView {
         animationTimeOffsetRule = NumberScrollAnimatedView.random
         animationDurationOffsetRule = NumberScrollAnimatedView.random
         scrollingDirectionRule = NumberScrollAnimatedView.random
-        inverseSequenceRule = NumberScrollAnimatedView.random
+        inverseSequenceRule = NumberScrollAnimatedView.randomBool
     }
 
     public func startAnimation() {
@@ -151,7 +151,7 @@ extension NumberScrollAnimatedView {
         return drand48()
     }
 
-    static func random(_ scrollableValue: String, _ forColumn: Int) -> Bool {
+    static func randomBool(_ scrollableValue: String, _ forColumn: Int) -> Bool {
         let randomValue = arc4random_uniform(2)
         if  randomValue == 0 {
             return true
@@ -172,8 +172,8 @@ extension NumberScrollAnimatedView {
 
 private extension String {
     func size(usingFont font: UIFont) -> CGSize {
-        let fontAttributes = [NSAttributedStringKey.font: font]
-        let size = self.size(withAttributes: fontAttributes)
+        let fontAttributes = [NSFontAttributeName: font]
+        let size = self.size(attributes: fontAttributes)
         return size
     }
 

--- a/NumbersScrollAnimatedView/NumberScrollableColumn.swift
+++ b/NumbersScrollAnimatedView/NumberScrollableColumn.swift
@@ -173,8 +173,8 @@ class NumberScrollableColumn {
         let attributedString = NSAttributedString(
             string: withText,
             attributes: [
-                NSAttributedStringKey.foregroundColor: textColor.cgColor,
-                NSAttributedStringKey.font: font
+                NSForegroundColorAttributeName: textColor.cgColor,
+                NSFontAttributeName: font
             ])
         newLayer.alignmentMode = kCAAlignmentCenter
         newLayer.string = attributedString


### PR DESCRIPTION
There are some syntax error in swift 3.
So I fix it. I would be happy to merge the request at new branch "swift 3" for users who like me.

It's my first pull request. So let me know if I wrote something wrong.
I'm used your library very useful in our company app :)
Thanks